### PR TITLE
Add option urlTransform

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ DEBUG=preview-email node app.js
   * `dir` (String) - a path to a directory for saving the generated email previews (defaults to `os.tmpdir()`, see [os docs](https://nodejs.org/api/os.html#os_os_tmpdir) for more insight)
   * `open` (Object or Boolean) - an options object that is passed to [open][] (defaults to `{ wait: false }`) - if set to `false` then it will not open the email automaitcally in the browser using [open][], and if set to `true` then it will default to `{ wait: false }`
   * `template` (String) - a file path to a `pug` template file (defaults to preview-email's [template.pug](template.pug) by default) - **this is where you can pass a custom template for rendering email previews, e.g. your own stylesheet**
+  * `urlTransform` (Function (path) => url) - a function to build preview url from file path (defaults to `(path) => 'file://[file path]'`) - _this is where you can customize the opened path to handle WSL to Windows tranformation or build a http url if `dir` is served._
 
 
 ## Contributors

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ const previewEmail = async (message, options) => {
     id: uuid.v4(),
     open: { wait: false },
     template: templateFilePath,
+    urlTransform: path => `file://${path}`,
     ...options
   };
   debug('message', message, 'options', options);
@@ -52,9 +53,10 @@ const previewEmail = async (message, options) => {
   debug('filePath', filePath);
   await writeFile(filePath, html);
 
-  if (options.open) await open(filePath, options.open);
+  const url = options.urlTransform(filePath);
+  if (options.open) await open(url, options.open);
 
-  return `file://${filePath}`;
+  return url;
 };
 
 module.exports = previewEmail;

--- a/test/test.js
+++ b/test/test.js
@@ -62,3 +62,14 @@ test('does not open in browser', async t => {
   const url = await previewEmail({}, { open: false });
   t.true(typeof url === 'string');
 });
+
+test('transform URL', async t => {
+  const url = await previewEmail(
+    {},
+    {
+      open: false,
+      urlTransform: path => `http://localhost:8000/${path}`
+    }
+  );
+  t.regex(url, /^http:\/\/localhost:8000\//);
+});


### PR DESCRIPTION
- Allow to pass a function to tranform file path to url
   - can transform WSL path to windows path if needed
- url provided to `open` instead of local path to allow usage of http (output files could be written to a served directory)

should fix #18

I am not very good at naming so tell if you want me to rename the option.