### PR TITLE
chore: update display-notification to v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const path = require('path');
 const process = require('process');
 const util = require('util');
 const { Buffer } = require('buffer');
-const displayNotification = require('display-notification');
 const getPort = require('get-port');
 const nodemailer = require('nodemailer');
 const open = require('open');
@@ -89,6 +88,7 @@ const previewEmail = async (message, options) => {
   // `xcrun simctl openurl booted ${url}`
   //
   if (isMacOS && !isCI && options.openSimulator) {
+    const { displayNotification } = await import('display-notification');
     try {
       // <https://github.com/sindresorhus/open/blob/05ba9e150cc1a2629e518a9cc19b586c6ca3f269/index.js#L205-L222>
       const simulator = childProcess.spawn('open', ['-a', 'Simulator']);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "ci-info": "^3.8.0",
-    "display-notification": "2.0.0",
+    "display-notification": "^3.0.0",
     "fixpack": "^4.0.0",
     "get-port": "5.1.1",
     "mailparser": "^3.7.1",


### PR DESCRIPTION
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

## Changes made

- Updates the version of `display-notification` from `2.0.0` to `3.0.0`
- Updates the module's `require` statement to be dynamic to align with the new version of `display-notification`

## Reason for the change

Some security scanners list the `0.10.0` version of the `execa` package as being vulnerable to a command injection attack. The `execa` package is a direct dependency of the `run-applescript` package which is a direct dependency of `display-notification`. This update upgrades `run-applescript` to a `^5.0.0` version which takes `execa` up to a `^5.0.0` version.

