### PR TITLE
fix: bump nodemailer to ^9.0.1 to resolve GHSA-p6gq-j5cr-w38f

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "fixpack": "^4.0.0",
     "get-port": "5.1.1",
     "mailparser": "^3.9.6",
-    "nodemailer": "^8.0.4",
+    "nodemailer": "^9.0.1",
     "open": "7",
     "p-event": "4.2.0",
     "p-wait-for": "3.2.0",


### PR DESCRIPTION
## Summary

Bumps `nodemailer` from `^8.0.4` to `^9.0.1` to resolve a high-severity advisory.

### Vulnerability

[GHSA-p6gq-j5cr-w38f](https://github.com/advisories/GHSA-p6gq-j5cr-w38f) (CVSS 7.1, high) — nodemailer `<=9.0.0` allowed the message-level `raw` option to bypass `disableFileAccess`/`disableUrlAccess`, enabling arbitrary file read and full-response SSRF in the delivered message. Fixed in nodemailer 9.0.1.

Confirmed locally with `npm audit`:

| Before | After |
| --- | --- |
| 1 high (nodemailer) | nodemailer no longer flagged |

### 9.x breaking-change assessment

The single breaking change in [nodemailer 9.0.0](https://github.com/nodemailer/nodemailer/releases/tag/v9.0.0) is that HTTPS requests fetching remote content (attachment `href`/`path` URLs, OAuth2 token endpoints, HTTP/HTTPS proxy `CONNECT`) now validate TLS certificates by default. `preview-email` uses nodemailer only via:

- `streamTransport: true` in [`index.js`](https://github.com/forwardemail/preview-email/blob/master/index.js) to serialize a message to a buffer in-process, and
- `jsonTransport: true` in the test suite.

Neither path fetches remote attachments, uses OAuth2, or proxies HTTPS, so the stricter TLS default has no behavioral impact here. No code changes are required.

The `engines.node` field is unaffected: nodemailer 9.x still declares `node: >=6.0.0`, well below this package's existing `>=14`.

## Test plan

- [x] `npm install` — installs nodemailer 9.0.1
- [x] `npm test` — 8/8 tests pass (lint + ava)
- [x] `npm audit` — nodemailer no longer appears in the report