### PR TITLE
fix: bump mailparser to ^3.9.14 to resolve linkify-it and nodemailer vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "display-notification": "^3.0.0",
     "fixpack": "^4.0.0",
     "get-port": "5.1.1",
-    "mailparser": "3.9.8",
+    "mailparser": "^3.9.14",
     "nodemailer": "^9.0.1",
     "open": "7",
     "p-event": "4.2.0",


### PR DESCRIPTION
## Summary

Bumps `mailparser` from `3.9.8` to `^3.9.14` to resolve several high-severity advisories.

## Vulnerabilities

`linkify-it`
- https://github.com/advisories/GHSA-22p9-wv53-3rq4
- https://github.com/advisories/GHSA-v245-v573-v5vm

`nodemailer`
- https://github.com/advisories/GHSA-p6gq-j5cr-w38f

_Before_

```
linkify-it  <=5.0.1
Severity: high
LinkifyIt#match scan loop has quadratic algorithmic complexity - https://github.com/advisories/GHSA-22p9-wv53-3rq4
linkify-it: Quadratic-complexity DoS via the `mailto:` validator scan-loop on attacker text - https://github.com/advisories/GHSA-v245-v573-v5vm
fix available via `npm audit fix --force`
Will install mailparser@3.9.14, which is outside the stated dependency range
node_modules/linkify-it
  mailparser  2.1.0 - 3.9.8
  Depends on vulnerable versions of linkify-it
  Depends on vulnerable versions of nodemailer
  node_modules/mailparser

nodemailer  <=9.0.0
Severity: high
Nodemailer: CRLF injection in Nodemailer List-* header comments allows arbitrary message header injection - https://github.com/advisories/GHSA-268h-hp4c-crq3
Nodemailer jsonTransport bypasses disableFileAccess and disableUrlAccess during message normalization - https://github.com/advisories/GHSA-wqvq-jvpq-h66f
Nodemailer: Improper TLS Certificate Validation in OAuth2 Token Fetch Enables Credential Interception - https://github.com/advisories/GHSA-r7g4-qg5f-qqm2
Nodemailer: Message-level raw option bypasses disableFileAccess/disableUrlAccess, enabling arbitrary file read and full-response SSRF in the delivered message - https://github.com/advisories/GHSA-p6gq-j5cr-w38f
fix available via `npm audit fix --force`
Will install mailparser@3.9.14, which is outside the stated dependency range
node_modules/mailparser/node_modules/nodemailer
```

_After_

No references to `linkify-it` or `nodemailer` in the audit.

## Breaking Change Assessment

`mailparser` [CHANGELOG](https://github.com/nodemailer/mailparser/blob/master/CHANGELOG.md) from `3.9.8` to `3.9.14` is just dependency bump with a small bug fix.

## Testing

- [x] `npm install` — installs `mailparser` `3.9.14`
- [x] `npm test` — 8/8 tests pass (lint + ava)
- [x] `npm audit` — no references to `linkify-it` or `nodemailer`

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
