### PR TITLE
chore: replace uuid package with Node-native crypto.randomUUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ NODE_DEBUG=preview-email node app.js
 
 * `message` (Object) - a [Nodemailer message configuration object](https://nodemailer.com/message/)
 * `options` (Object) - an object with the following two properties:
-  * `id` (String) - a unique ID for the file name created for the preview in `dir` (defaults to `uuid.v4()` from [uuid][])
+  * `id` (String) - a unique ID for the file name created for the preview in `dir` (defaults to [`crypto.randomUUID()`](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions))
   * `dir` (String) - a path to a directory for saving the generated email previews (defaults to `os.tmpdir()`, see [os docs](https://nodejs.org/api/os.html#os_os_tmpdir) for more insight)
   * `open` (Object or Boolean) - an options object that is passed to [open][] (defaults to `{ wait: false }`) - if set to `false` then it will not open the email automatically in the browser using [open][], and if set to `true` then it will default to `{ wait: false }`
   * `template` (String) - a file path to a `pug` template file (defaults to preview-email's [template.pug](template.pug) by default) - **this is where you can pass a custom template for rendering email previews, e.g. your own stylesheet**
@@ -152,8 +152,6 @@ NODE_DEBUG=preview-email node app.js
 [node]: https://nodejs.org/
 
 [nodemailer]: https://nodemailer.com
-
-[uuid]: https://github.com/kelektiv/node-uuid
 
 [lad]: https://lad.js.org
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const childProcess = require('child_process');
+const crypto = require('crypto');
 const fs = require('fs');
 const http = require('http');
 const os = require('os');
@@ -12,7 +13,6 @@ const open = require('open');
 const pEvent = require('p-event');
 const pWaitFor = require('p-wait-for');
 const pug = require('pug');
-const uuid = require('uuid');
 const { isCI } = require('ci-info');
 const { simpleParser } = require('mailparser');
 
@@ -31,7 +31,7 @@ let displayNotification;
 const previewEmail = async (message, options) => {
   options = {
     dir: os.tmpdir(),
-    id: uuid.v4(),
+    id: crypto.randomUUID(),
     open: { wait: false },
     template: templateFilePath,
     urlTransform: (path) => `file://${path}`,

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "open": "7",
     "p-event": "4.2.0",
     "p-wait-for": "3.2.0",
-    "pug": "^3.0.3",
-    "uuid": "^9.0.1"
+    "pug": "^3.0.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",
@@ -38,7 +37,7 @@
     "xo": "^0.54.2"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=14.17"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
Replaces #53, fixes #52 by removing `uuid` entirely.

As mentioned in https://github.com/forwardemail/preview-email/pull/53#issuecomment-4859347576: `crypto.randomUUID()` is only introduced in Node 14.17, and the `preview-email` package has `"engines": { "node": ">=14" }`. Forcing the minor version (`">=14.17"`) works fine, but I don't know how strict you are with breaking changes in that regard.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
